### PR TITLE
Gcc support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ conditionDefs_$(PROC).h driver.c slinkyExpressions.h
 HEADERS = macrossTypes.h macrossGlobals.h
 
 CFLAGS=-m32 # macross is not 64 bit clean
+# If yacc is notionally present on a system, it's usually actually
+# bison in a compatibility mode. bison is available by name more often
+# than bison itself is.
+YACC=bison -o y.tab.c
 
 .c.o:
 	cc $(CFLAGS) -c -g -DTARGET_CPU=CPU_$(PROC) $*.c
@@ -153,10 +157,10 @@ y.tab.o: y.tab.c $(HEADERS)
 	cc $(CFLAGS) -c -g -DYYDEBUG -DTARGET_CPU=CPU_$(PROC) y.tab.c
 
 y.tab.c y.tab.h: macross_$(PROC).y
-	yacc -d macross_$(PROC).y
+	$(YACC) -d macross_$(PROC).y
 
 y.output: macross_$(PROC).y
-	yacc -vd macross_$(PROC).y
+	$(YACC) -vd macross_$(PROC).y
 
 cleanup:
 	/bin/rm -f *.o y.output y.tab.c y.tab.h macross

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ move: .mark
 	date >/net/kessel/u0/chip/macross/prof/.mark
 	date >opt/.mark
 
-macrossTypes.h: macrossTypes.h operandDefs_$(PROC).h operandBody_$(PROC).h\
+macrossTypes.h: operandDefs_$(PROC).h operandBody_$(PROC).h\
 conditionDefs_$(PROC).h
 
 actions.o: actions_$(PROC).c $(HEADERS)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ lookups.c macrossTables_$(PROC).c main.c malloc.c object.c\
 operandStuffSD_$(PROC).c parserMisc.c semanticMisc.c statementSemantics.c\
 structSemantics.c tokenStrings_$(PROC).c lexerTables.h macrossGlobals.h\
 macrossTypes.h operandDefs_$(PROC).h operandBody_$(PROC).h\
-conditionDefs_$(PROC).h driver.c slinkyExpressions.h
+conditionDefs_$(PROC).h driver.c slinkyExpressions.h\
+operandStuff.h statementSemantics.h listing.h parserMisc.h\
+emitBranch.h semanticMisc.h expressionSemantics.h
 
 HEADERS = macrossTypes.h macrossGlobals.h
 
@@ -90,7 +92,7 @@ buildStuff2.o: buildStuff2.c $(HEADERS)
 
 buildStuff3.o: buildStuff3.c $(HEADERS)
 
-builtInFunctions.o: builtInFunctions.c $(HEADERS)
+builtInFunctions.o: builtInFunctions.c $(HEADERS) expressionSemantics.h operandStuff.h semanticMisc.h
 
 builtInFunsSD.o: builtInFunsSD_$(PROC).c $(HEADERS)
 	cc $(CFLAGS) -c -g -DTARGET_CPU=CPU_$(PROC) builtInFunsSD_$(PROC).c
@@ -109,11 +111,11 @@ emitBranch.o: emitBranch_$(PROC).c $(HEADERS)
 emitStuff.o: emitStuff.c $(HEADERS)
 	cc $(CFLAGS) -c -g -DTARGET_CPU=CPU_$(PROC) emitStuff.c
 
-encode.o: encode.c $(HEADERS)
+encode.o: encode.c $(HEADERS) y.tab.h semanticMisc.h slinkyExpressions.h
 
 errorStuff.o: errorStuff.c $(HEADERS)
 
-expressionSemantics.o: expressionSemantics.c y.tab.h $(HEADERS)
+expressionSemantics.o: expressionSemantics.c y.tab.h $(HEADERS) expressionSemantics.h semanticMisc.h
 
 fixups.o: fixups.c $(HEADERS)
 
@@ -121,9 +123,9 @@ garbage.o: garbage.c y.tab.h $(HEADERS)
 
 initialize.o: initialize.c $(HEADERS)
 
-lexer.o: lexer.c lexerTables.h y.tab.h $(HEADERS)
+lexer.o: lexer.c lexerTables.h y.tab.h $(HEADERS) parserMisc.h
 
-listing.o: listing.c $(HEADERS)
+listing.o: listing.c $(HEADERS) listing.h
 
 lookups.o: lookups.c $(HEADERS)
 
@@ -141,11 +143,11 @@ operandStuffSD.o: operandStuffSD_$(PROC).c $(HEADERS)
 	cc $(CFLAGS) -c -g -DTARGET_CPU=CPU_$(PROC) operandStuffSD_$(PROC).c
 	mv operandStuffSD_$(PROC).o operandStuffSD.o
 
-parserMisc.o: parserMisc.c y.tab.h $(HEADERS)
+parserMisc.o: parserMisc.c y.tab.h $(HEADERS) parserMisc.h
 
-semanticMisc.o: semanticMisc.c $(HEADERS)
+semanticMisc.o: semanticMisc.c $(HEADERS) semanticMisc.h expressionSemantics.h
 
-statementSemantics.o: statementSemantics.c $(HEADERS)
+statementSemantics.o: statementSemantics.c $(HEADERS) emitBranch.h expressionSemantics.h operandStuff.h parserMisc.h semanticMisc.h statementSemantics.h
 
 structSemantics.o: structSemantics.c $(HEADERS)
 

--- a/debugPrint.c
+++ b/debugPrint.c
@@ -32,6 +32,8 @@
 #include "macrossGlobals.h"
 #include "y.tab.h"
 
+void printExpression(expressionType *expression);
+
 /*
    Print out the parse-tree.
  */
@@ -274,7 +276,6 @@ printArrayTerm(arrayTerm)
   arrayTermType	*arrayTerm;
 {
 	void	printIdentifier();
-	void	printExpression();
 
 	nullPrint(arrayTerm);
 	tab(); printf("(array\n");
@@ -289,7 +290,6 @@ printArrayTerm(arrayTerm)
 printAssignmentTerm(assignmentTerm)
   binopTermType	*assignmentTerm;
 {
-	void	printExpression();
 
 	nullPrint(assignmentTerm);
 	tab(); printf("(assignment [");
@@ -307,7 +307,6 @@ printBinopTerm(binopTerm)
   binopTermType	*binopTerm;
 {
 	void	printIdentifier();
-	void	printExpression();
 
 	nullPrint(binopTerm);
 	tab(); printf("(binop [");
@@ -391,8 +390,6 @@ printPreopTerm(preopTerm)
 printUnopTerm(unopTerm)
   unopTermType	*unopTerm;
 {
-	void	printExpression();
-
 	nullPrint(unopTerm);
 	tab(); printf("(unop [");
 	       printToken(unopTerm->unop);

--- a/emitBranch.h
+++ b/emitBranch.h
@@ -1,0 +1,16 @@
+#ifndef EMIT_BRANCH_H_
+#define EMIT_BRANCH_H_
+
+#include "macrossTypes.h"
+
+#if TARGET_CPU == CPU_6502
+void emitRelativeBranch(conditionType condition, valueType *target, valueType fixupLocation[COMPOUND_BRANCH_MAX]);
+#elif TARGET_CPU == CPU_68000
+void emitRelativeBranch(conditionType condition, valueType *target, valueType *fixupLocation);
+#else
+#error Missing or invalid TARGET_CPU
+#endif
+
+simpleFixupListType *emitJump(valueType *target, simpleFixupListType *previousFixups);
+
+#endif

--- a/encode.c
+++ b/encode.c
@@ -31,6 +31,7 @@
 #include "macrossTypes.h"
 #include "macrossGlobals.h"
 #include "y.tab.h"
+#include "semanticMisc.h"
 #include "slinkyExpressions.h"
 
 #define nullEncode(thing)   if (thing==NULL) return(TRUE);
@@ -132,8 +133,6 @@ encodeFunctionCall(functionCall)
 	int			 functionOrdinal;
 	symbolInContextType	*workingContext;
 	operandListType		*parameterList;
-
-	symbolInContextType	*getWorkingContext();
 
 	nullEncode(functionCall);
 	workingContext = getWorkingContext(functionCall->functionName);

--- a/expressionSemantics.c
+++ b/expressionSemantics.c
@@ -31,6 +31,8 @@
 #include "macrossTypes.h"
 #include "macrossGlobals.h"
 #include "y.tab.h"
+#include "expressionSemantics.h"
+#include "semanticMisc.h"
 
 operandType		*dbOperand;	/* safe temps for dbx hacking */
 expressionType		*dbExpression;
@@ -70,8 +72,6 @@ arrayLookup(arrayTerm, kindOfThing)
 	arrayType		*array;
 	int			 index;
 	stringType		*string;
-
-	valueType		*evaluateExpression();
 
 	*kindOfThing = FAIL;
 	arrayValue = evaluateExpression(arrayTerm->arrayName, NO_FIXUP);
@@ -133,9 +133,6 @@ evaluateArrayTerm(arrayTerm)
 	environmentType		*saveEnvironment;
 	bool			 saveExpansion;
 
-	valueType		*newValue();
-	valueType		*evaluateOperand();
-
 	expansionOff();
 	resultThing = arrayLookup(arrayTerm, &kindOfResult);
 	expansionOn();
@@ -186,15 +183,6 @@ evaluateAssignmentTerm(assignmentTerm, kindOfFixup)
 	bool			 stringAssign;
 	char			*charPtr;
 	char			 objectChar;
-
-	symbolTableEntryType	*effectiveSymbol();
-	valueType		*evaluateExpressionInternally();
-	valueKindType		 addValueKind();
-	valueKindType		 selectValueKind();
-	valueKindType		 subValueKind();
-	valueKindType		 opValueKind();
-	valueType		*makeUndefinedValue();
-	valueType		*newValue();
 
     nullEvaluate(assignmentTerm);
     sideEffectFlag = TRUE;
@@ -385,11 +373,6 @@ evaluateBinopTerm(binopTerm, isTopLevel, kindOfFixup)
 	int			 resultValue;
 	operandKindType		 resultAddressMode;
 	valueType		*result;
-
-	symbolInContextType	*getWorkingContext();
-	valueType		*evaluateExpressionInternally();
-	valueType		*newValue();
-	valueType		*makeUndefinedValue();
 
 	nullEvaluate(binopTerm);
 	if (binopTerm->binop != SUB && binopTerm->binop != ADD)
@@ -598,8 +581,6 @@ evaluateBinopTerm(binopTerm, isTopLevel, kindOfFixup)
 evaluateCondition(condition)
   conditionType	condition;
 {
-	valueType	*newValue();
-
 	expand(moreExpression("%s", conditionString(condition)));
 	return(newValue(CONDITION_VALUE, condition, EXPRESSION_OPND));
 }
@@ -632,10 +613,6 @@ evaluateFunctionCall(functionCall, kindOfFixup, isStandalone)
 	environmentType		 newEnvironment;
 	valueType		*result;
 	bool			 saveExpansion;
-
-	symbolInContextType	*getWorkingContext();
-	valueType		*evaluateBuiltInFunctionCall();
-	valueType		*newValue();
 
 	nullEvaluate(functionCall);
 	sideEffectFlag = TRUE;
@@ -705,7 +682,6 @@ evaluateFunctionCall(functionCall, kindOfFixup, isStandalone)
   valueType *
 evaluateHere()
 {
-	valueType	*newValue();
 	valueType	*result;
 
 	expand(moreExpression("here"));
@@ -726,11 +702,6 @@ evaluateIdentifier(identifier, isTopLevel, kindOfFixup)
 	valueType		*result;
 	environmentType		*saveEnvironment;
 	bool			 saveExpansion;
-
-	valueType		*newValue();
-	valueType		*evaluateOperand();
-	symbolInContextType	*getWorkingContext();
-	symbolTableEntryType	*generateLocalLabel();
 
 	nullEvaluate(identifier);
 	identifier->referenceCount++;
@@ -851,8 +822,6 @@ evaluateIdentifier(identifier, isTopLevel, kindOfFixup)
 evaluateNumber(number)
   numberTermType	number;
 {
-	valueType	*newValue();
-
 	expand(moreExpression("0x%x", number));
 	return(newValue(ABSOLUTE_VALUE, number, EXPRESSION_OPND));
 }
@@ -867,9 +836,6 @@ evaluatePostopTerm(postopTerm)
 	valueType		*result;
 	symbolInContextType	*workingContext;
 	symbolTableEntryType	*targetSymbol;
-
-	symbolTableEntryType	*effectiveSymbol();
-	symbolInContextType	*getWorkingContext();
 
 	nullEvaluate(postopTerm);
 	sideEffectFlag = TRUE;
@@ -939,9 +905,6 @@ evaluatePreopTerm(preopTerm)
 	symbolInContextType	*workingContext;
 	symbolTableEntryType	*targetSymbol;
 
-	symbolTableEntryType	*effectiveSymbol();
-	symbolInContextType	*getWorkingContext();
-
 	nullEvaluate(preopTerm);
 	sideEffectFlag = TRUE;
 	if (preopTerm->preOpArgument->kindOfTerm == IDENTIFIER_EXPR) {
@@ -1003,7 +966,6 @@ evaluatePreopTerm(preopTerm)
 evaluateString(string)
   stringType	*string;
 {
-	valueType	*newValue();
 	stringType	*newString;
 
 	expand(moreExpression("\"%s\"", string));
@@ -1022,11 +984,6 @@ evaluateUnopTerm(unopTerm, kindOfFixup)
 	int		 resultValue;
 	operandKindType	 resultAddressMode;
 	valueType	*result;
-
-	valueKindType	 unopValueKind();
-	valueType	*newValue();
-	valueType	*evaluateExpressionInternally();
-	valueType	*makeUndefinedValue();
 
 	nullEvaluate(unopTerm);
 	expand(moreExpression("%s", tokenString(unopTerm->unop)));
@@ -1213,10 +1170,6 @@ evaluateExpressionStandalone(expression)
 evaluateDefineExpression(expression)
   expressionType	*expression;
 {
-	valueType	*newValue();
-	expressionType	*generateFixupExpression();
-	operandType	*buildOperand();
-
 	nullEvaluate(expression);
 	return(newValue(OPERAND_VALUE, buildOperand(EXPRESSION_OPND,
 		generateFixupExpression(expression)), EXPRESSION_OPND));
@@ -1227,7 +1180,6 @@ evaluateSelectionList(selectionList)
   selectionListType	*selectionList;
 {
 	int		 offset;
-	valueType	*newValue();
 
 	offset = 0;
 	while (selectionList != NULL) {

--- a/expressionSemantics.h
+++ b/expressionSemantics.h
@@ -1,0 +1,25 @@
+#ifndef EXPRESSION_SEMANTICS_H_
+#define EXPRESSION_SEMANTICS_H_
+#include "macrossTypes.h"
+
+anyOldThing *arrayLookup(arrayTermType *arrayTerm, valueKindType *kindOfThing);
+valueType *evaluateArrayTerm(arrayTermType *arrayTerm);
+valueType *evaluateAssignmentTerm(binopTermType *assignmentTerm, fixupKindType kindOfFixup);
+valueType *evaluateBinopTerm(binopTermType *assignmentTerm, bool isTopLevel, fixupKindType kindOfFixup);
+valueType *evaluateCondition(conditionType condition);
+valueType *evaluateBuiltInFunctionCall(symbolInContextType *workingContext, operandListType *parameters, fixupKindType kindOfFixup);
+valueType *evaluateFunctionCall(functionCallTermType *functionCall, fixupKindType kindOfFixup, bool isStandalone);
+valueType *evaluateHere();
+valueType *evaluateIdentifier(symbolTableEntryType *identifier, bool isTopLevel, fixupKindType kindOfFixup);
+valueType *evaluateNumber(numberTermType number);
+valueType *evaluatePostopTerm(postOpTermType *postopTerm);
+valueType *evaluatePreopTerm(preOpTermType *preopTerm);
+valueType *evaluateString(stringType *string);
+valueType *evaluateUnopTerm(unopTermType* unopTerm, fixupKindType kindOfFixup);
+valueType *evaluateExpressionInternally(expressionType *expression, bool isToplevel, fixupKindType kindOfFixup, bool isStandalone);
+valueType *evaluateExpression(expressionType *expression, fixupKindType kindOfFixup);
+void evaluateExpressionStandalone(expressionType *expression);
+valueType *evaluateDefineExpression(expressionType *expression);
+valueType *evaluateSelectionList(selectionListType *selectionList);
+
+#endif

--- a/lexer.c
+++ b/lexer.c
@@ -31,6 +31,7 @@
 #include "macrossGlobals.h"
 #include "y.tab.h"
 #include "lexerTables.h"
+#include "parserMisc.h"
 
 extern int yylval;
 extern int yydebug;

--- a/listing.c
+++ b/listing.c
@@ -29,6 +29,7 @@
 
 #include "macrossTypes.h"
 #include "macrossGlobals.h"
+#include "listing.h"
 
 static char	 lineBuffer1[LINE_BUFFER_SIZE];
 static char	 lineBuffer2[LINE_BUFFER_SIZE];
@@ -43,8 +44,6 @@ static int	 nextMacroDepth;
   void
 outputListing()
 {
-	void	generateListing();
-
 	rewind(saveFileForPass2);
 	rewind(indexFileForPass2);
 	rewind(macroFileForPass2);
@@ -121,9 +120,6 @@ generateListing()
 	int			 numberOfBytesToList;
 	int			 numberOfBytesListed;
 	char			*tempText;
-
-	void			 readIndexFileLine();
-	void			 readSourceFileLine();
 
 	sourceLineNumber = 1;
 	alreadyListingMacroExpansion = FALSE;
@@ -362,8 +358,6 @@ printListingLine(numberOfBytes, byteAddress, text, kind)
 {
 	int	i;
 
-	void	tabPrint();
-
 	if (kind != BLOCK_STATEMENT)
 		numberOfBytes = (numberOfBytes < 4) ? numberOfBytes : 4;
 
@@ -484,10 +478,8 @@ printNTimes(aChar, times)
   char	aChar;
   int	times;
 {
-	void	moreText();
-
 	while (times-- > 0)
-		moreText("%c", aChar);
+            moreText("%c", aChar, 0, 0);
 }
 
   void
@@ -595,9 +587,9 @@ expandExpression(toBuffer, toBufferPtr)
   char	**toBufferPtr;
 {
 	if (toBuffer == NULL)
-		moreText("%s", expressionString);
+		moreText("%s", expressionString, 0, 0);
 	else
-		addText(toBuffer, toBufferPtr, "%s", expressionString);
+		addText(toBuffer, toBufferPtr, "%s", expressionString, 0, 0);
 	flushExpressionString();
 }
 
@@ -607,14 +599,14 @@ expandNum(buffer, bufferPtr, n)
   char	**bufferPtr;
   int	  n;
 {
-	moreTextOptional(buffer, bufferPtr, "%d", n);
+	moreTextOptional(buffer, bufferPtr, "%d", n, 0, 0);
 }
 
   void
 flushOperand(n)
   int	n;
 {
-	moreText("%s", operandBuffer[n]);
+	moreText("%s", operandBuffer[n], 0, 0);
 	operandBuffer[n][0] = '\0';
 }
 
@@ -627,7 +619,7 @@ expandOperands(op)
 	if (op > 0) {
 		flushOperand(0);
 		for (i=1; i<op; i++) {
-			moreText(", ");
+			moreText(", ", 0, 0, 0);
 			flushOperand(i);
 		}
 	}
@@ -636,7 +628,7 @@ expandOperands(op)
   void
 expandLabel()
 {
-	moreText("%s", labelString);
+	moreText("%s", labelString, 0, 0);
 	labelStringPtr = labelString;
 	*labelStringPtr = '\0';
 }

--- a/listing.h
+++ b/listing.h
@@ -1,0 +1,41 @@
+#ifndef LISTING_H_
+#define LISTING_H_
+
+/* TODO: Functions here that have "format" arguments should actually
+ * be varargs. In 1984 it probably wasn't standardized, but here in
+ * Glorious Future Year 1989 the vprintf function does almost exactly
+ * what we want. */
+
+void outputListing();
+void terminateListingFiles();
+void generateListing();
+int printMacroLine(int numberOfBytes, int byteAddress, statementKindType kind);
+void readSourceFileLine(int *sourceAddressPtr, int *sourceDepthPtr, char lineBuffer[], FILE *file);
+void readIndexFileLine(statementKindType *statementKindPtr, int *indexAddressPtr, int *indexLineNumberPtr);
+int printListingLine(int numberOfBytes, int byteAddress, char *text, statementKindType kind);
+bool isBlockOpener(statementKindType statementKind);
+bool isBlankStatment(statementKindType statementKind);
+void tabPrint(stringType *text);
+void printNTimes (char aChar, int times);
+void tabIndent();
+bool labeledLine();
+void addText(char *buffer, char **bufferPtr, char *format, int arg1, int arg2, int arg3);
+void moreTextOptional(char *buffer, char **bufferPtr, char *format, int arg1, int arg2, int arg3);
+void moreText(char *format, int arg1, int arg2, int arg3);
+void moreLabel(char *format, int arg1, int arg2, int arg3);
+void startLine();
+void endLine();
+void flushExpressionString();
+void expandExpression(char *toBuffer, char **toBufferPtr);
+void expandNum(char *buffer, char **bufferPtr, int n);
+void flushOperand(int n);
+void expandOperands(int op);
+void expandLabel();
+void moreExpression(char *format, int arg1, int arg2, int arg3);
+void startLineMarked();
+bool notListable(statementKindType statementKind);
+
+#endif
+
+
+

--- a/macrossTypes.h
+++ b/macrossTypes.h
@@ -28,6 +28,9 @@
 
 */
 
+#ifndef MACROSS_TYPES_H_
+#define MACROSS_TYPES_H_
+
 #include <stdio.h>
 
 /*
@@ -1093,3 +1096,5 @@ typedef enum {/* horrible kludge due to C compiler bug on Sun */
 /* Boy, is this macro useful! */
 
 #define typeAlloc(type)	(type *)malloc(sizeof(type))
+
+#endif

--- a/operandStuff.h
+++ b/operandStuff.h
@@ -1,0 +1,21 @@
+#ifndef OPERAND_STUFF_H_
+#define OPERAND_STUFF_H_
+
+#include "macrossTypes.h"
+
+#if TARGET_CPU == CPU_6502
+operandType *buildOperand(operandKindType kindOfOperand, anyOldThing *arg);
+#elif TARGET_CPU == CPU_68000
+operandType *buildOperand(operandKindType kindOfOperand, int arg1, int arg2, int arg3, int arg4);
+#else
+#error Unknown or undefined processor type
+#endif
+
+operandListType *duplicateOperandForFixup(operandListType *operand, bool isSpecialFunctionOperand);
+void expandOperand(operandKindType addressMode, char *buffer);
+void freeOperand(operandType *operand);
+valueType *evaluateOperand(operandType *operand);
+conditionType invertConditionCode(conditionType conditionCode);
+bool shouldParethesize(operandType *operand);
+
+#endif

--- a/operandStuffSD_6502.c
+++ b/operandStuffSD_6502.c
@@ -229,8 +229,9 @@ freeOperand(operand)
 /* corresponds to routines in listing.c */
 
   void
-expandOperand(addressMode)
+expandOperand(addressMode, buffer)
   operandKindType	addressMode;
+  char *		buffer;
 {
 	switch (addressMode) {
 	case IMMEDIATE_OPND:		moreText("#"); break;

--- a/parserMisc.c
+++ b/parserMisc.c
@@ -32,6 +32,7 @@
 #include "macrossTypes.h"
 #include "macrossGlobals.h"
 #include "y.tab.h"
+#include "parserMisc.h"
 
   statementType *
 addLabelToStatement(labelList, statement)
@@ -46,12 +47,16 @@ addLabelToStatement(labelList, statement)
 	return(statement);
 }
 
+/* TODO: This should be a varargs function. In 1984 it probably wasn't
+ * standardized, but here in Glorious Future Year 1989 the vprintf
+ * function does almost exactly what we want. */
+
   void
 botch(message, arg1, arg2, arg3)
   char		*message;
-  anyOldThing	*arg1;
-  anyOldThing	*arg2;
-  anyOldThing	*arg3;
+  int           arg1;
+  int           arg2;
+  int           arg3;
 {
 	printf("Macross horrible terrible internal botch: ");
 	printf(message, arg1, arg2, arg3);
@@ -72,7 +77,7 @@ convertDefineToMdefine(defineStatement)
 {
 	if (defineStatement->kindOfStatement != DEFINE_STATEMENT)
 		botch("convertDefineToMdefine got statement kind: %d\n",
-			defineStatement->kindOfStatement);
+			defineStatement->kindOfStatement, 0, 0);
 	defineStatement->kindOfStatement = MDEFINE_STATEMENT;
 	return(defineStatement);
 }
@@ -85,9 +90,9 @@ extractIfBody(ifStatement)
 
 	result = ifStatement->statementBody.ifUnion;
 	if (ifStatement->labels != NULL)
-		botch("extract if body with non-null labels\n");
+		botch("extract if body with non-null labels\n", 0, 0, 0);
 	else if (ifStatement->nextStatement != NULL)
-		botch("extract if body with non-null next\n");
+		botch("extract if body with non-null next\n", 0, 0, 0);
 	else
 		qfree(ifStatement);
 	return(result);
@@ -101,9 +106,9 @@ extractMifBody(mifStatement)
 
 	result = mifStatement->statementBody.mifUnion;
 	if (mifStatement->labels != NULL)
-		botch("extract mif body with non-null labels\n");
+		botch("extract mif body with non-null labels\n", 0, 0, 0);
 	else if (mifStatement->nextStatement != NULL)
-		botch("extract mif body with non-null next\n");
+		botch("extract mif body with non-null next\n", 0, 0, 0);
 	else
 		qfree(mifStatement);
 	return(result);
@@ -117,7 +122,7 @@ extractString(textExpression)
 
 	if (textExpression->kindOfOperand != STRING_OPND)
 		botch("extract string got handed an opnd kind: %d\n",
-			textExpression->kindOfOperand);
+			textExpression->kindOfOperand, 0, 0);
 	result = textExpression->theOperand.stringUnion;
 	qfree(textExpression);
 	return(result);

--- a/parserMisc.h
+++ b/parserMisc.h
@@ -1,0 +1,16 @@
+#ifndef PARSER_MISC_H_
+#define PARSER_MISC_H_
+#include "macrossTypes.h"
+
+statementType *addLabelToSatement(labelListType *labelList, statementType *statement);
+void botch(char *message, int arg1, int arg2, int arg3);
+void checkDefineAssignmentOperator(assignmentKindType assignmentOperator);
+void convertDefineToMDefine(statementType *defineStatement);
+ifStatementBodyType *extractIfBody(statementType *ifStatement);
+mifStatementBodyType *extractMifBody(statementType *mifStatement);
+stringType *extractString(operandType *textExpression);
+void popMacroOrFunctionNestingDepth();
+void pushMacroOrFunctionNestingDepth();
+char *saveString(char *s);
+
+#endif

--- a/semanticMisc.c
+++ b/semanticMisc.c
@@ -32,6 +32,9 @@
 #include "macrossGlobals.h"
 #include "y.tab.h"
 
+#include "semanticMisc.h"
+#include "expressionSemantics.h"
+
 #define expansionOff() {saveExpansion=expandMacros; expandMacros=FALSE;}
 #define expansionOn()	expandMacros=saveExpansion;
 
@@ -219,7 +222,6 @@ booleanTest(expression)
 	bool		 result;
 	valueType	*expressionResult;
 	bool		 saveExpansion;
-	valueType	*evaluateExpression();
 
 	expansionOff();
 	expressionResult = evaluateExpression(expression, NO_FIXUP);
@@ -1009,7 +1011,6 @@ noteReference(expression, kindOfFixup, location, codeMode)
 performFixups(fixups)
   fixupListType		*fixups;
 {
-	valueType	*evaluateExpression();
 	valueType	*valueToPoke;
 
 	performingFixups = TRUE;

--- a/semanticMisc.h
+++ b/semanticMisc.h
@@ -13,7 +13,7 @@ bool booleanTest(expressionType *expression);
 int countArguments(functionDefinitionType *function);
 int countParameters(operandListType *parameterList);
 arrayType *allocArray(int size, valueType ***contentsPtr);
-valueType *createArray(expresionType *dimension, expressionListType *initializers);
+valueType *createArray(expressionType *dimension, expressionListType *initializers);
 bool decrementable(valueType *value);
 int expressionListLength(expressionListType *expressionList);
 int fieldValue(symbolTableEntryType *symbol);

--- a/semanticMisc.h
+++ b/semanticMisc.h
@@ -1,0 +1,66 @@
+#ifndef SEMANTIC_MISC_H_
+#define SEMANTIC_MISC_H_
+
+#include "macrossTypes.h"
+
+/* Miscellaneous */
+bool absoluteValue(valueType *address);
+void addAttributeToSymbol(symbolTableEntryType *symbol, symbolAttributesType attribute);
+addressType addressValue(valueType *value);
+valueKindType addValueKind(valueType *leftOperand, valueType *rightOperand);
+bool alreadyDefined(symbolInContextType *context);
+bool booleanTest(expressionType *expression);
+int countArguments(functionDefinitionType *function);
+int countParameters(operandListType *parameterList);
+arrayType *allocArray(int size, valueType ***contentsPtr);
+valueType *createArray(expresionType *dimension, expressionListType *initializers);
+bool decrementable(valueType *value);
+int expressionListLength(expressionListType *expressionList);
+int fieldValue(symbolTableEntryType *symbol);
+bool incrementable(valueType *value);
+int intValue(valueType *value);
+bool isAssignable(symbolInContextType *context);
+bool isBuiltInFunction(symbolInContextType *context);
+bool isDefinable(symbolInContextType *context);
+bool isExternal(symbolTableEntryType *symbol);
+bool isFailure(valueType *value);
+bool isFunction(symbolInContextType *context);
+bool isLastStatementInBlock(statementType *statement);
+bool isLogicalOp(int op);
+bool isPotentialVariable(symbolInContextType *context);
+bool isUndefined(valueType *value);
+bool isUsable(valueType *value);
+bool logicalXOR(int int1, int int2);
+valueType *newValue(valueKindType kindOfValue, int value, operandKindType addressMode);
+valueKindType opValueKind(valueType *leftOperand, valueType *rightOperand);
+bool relocatableValue(valueType *address);
+valueKindType selectValueKind(valueType *leftOperand, valueType *rightOperand);
+valueKindType subValueKind(valueType *leftOperand, valueType *rightOperand);
+int swab(int i);
+valueType *swabValue(valueType *value);
+valueKindType unopValueKind(valueType *operand);
+void valueField(symbolTableEntryType *symbol, valueType *value);
+void valueLabel(symbolTableEntryType *symbol, valueType *value);
+
+/* Fixups and references */
+void createFixup(expressionType *expression, addressType location, fixupKindType kindOfFixup, codeBufferKindType codeMode, int whichFixup);
+void finishUp();
+void noteAnonymousReference();
+void noteReference(expressionType *expression, fixupKindType kindOfFixup, addressType location, codeBufferKindType codeMode);
+void performFixups(fixupListType *fixups);
+void performStartAddressFixup();
+void putFixupsHere(fixupKindType kindOfFixupsToPut, int whichFixup);
+
+/* Contexts and dynamic symbol creation */
+void addNewLocalVariable(symbolTableEntryType *symbol);
+symbolTableEntryType *effectiveSymbol(symbolTableEntryType *symbol, symbolInContextType **assignmentTargetContext);
+symbolTableEntryType *generateLocalLabel(symbolTableEntryType *symbol);
+symbolInContextType *getBaseContext(symbolTableEntryType *identifier);
+symbolInContextType *getWorkingContext(symbolTableEntryType *identifier);
+stringType *localLabelString(symbolTableEntryType *symbol);
+int localLabelTagValue(symbolTableEntryType *symbol);
+void addBreak(codeBreakKindType kind, int data);
+void reserveAbsolute(addressType startAddress, int blockSize);
+bool listableStatement(statementKindType kind);
+
+#endif

--- a/statementSemantics.h
+++ b/statementSemantics.h
@@ -1,0 +1,54 @@
+#ifndef STATEMENT_SEMANTICS_H_
+#define STATEMENT_SEMANTICS_H_
+
+#include "macrossTypes.h"
+
+void assembleBlock(blockType *block);
+simpleFixupListType *assembleBlockInsideIf(blockType *block, simpleFixupListType *ongoingFixupList);
+bool operandCheck(opcodeTableEntryType *opcode, int numberOfOperands, valueType *evaluatedOperands[]);
+void assembleMachineInstruction(opcodeTableEntryType *opcode, operandListType *operands);
+void assembleMacro(macroTableEntryType *macroInstruction, operandListType *operands);
+void assembleAlignStatement(alignStatementBodyType *alignStatement);
+void assembleAssertStatement(assertStatementBodyType *assertStatement);
+void assembleBlockStatement(blockStatementBodyType *blockStatement);
+void assembleByteStatement(byteStatementBodyType *byeStatement);
+void assembleConstrainStatement(constrainStatementBodyType *constrainStatement);
+void assembleDbyteStatement(dbyteStatementBodyType *dbyteStatement);
+void assembleDefineStatement(defineStatementBodyType *defineStatement);
+void assembleDoUntilStatement(doUntilStatementBodyType *doUntilStatement);
+void assembleDoWhileStatement(doWhileStatementBodyType *doWhileStatement);
+void assembleExternStatement(externStatementBodyType *externStatement);
+void assembleFReturnStatement(freturnStatementBodyType *freturnStatement);
+void assembleFunctionStatement(functionStatementBodyType *functionStatement);
+void assembleGroupStatement(blockType *groupStatement);
+simpleFixupListType *assembleIfStatement(ifStatementBodyType *ifStatement, bool terminalIf, simpleFixupListType *ongoingFixupList);
+void assembleIfStatementOldStyle(ifStatementBodyType *ifStatement);
+void assembleIncludeStatement(includeStatementBodyType *includeStatement);
+void assembleInstructionStatement(instructionStatementBodyType *Statement, int cumulativeLineNumber);
+void assembleLongStatement(longStatementBodyType *longStatement);
+void assembleMacroStatement(macroStatementBodyType *macroStatement);
+void assembleMdefineStatement(defineStatementBodyType *mdefineStatement);
+void assembleMdoUntilStatement(mdoUntilStatementBodyType *mdoUntilStatement);
+void assembleMdoWhileStatement(mdoWhileStatementBodyType *mdoWhileStatement);
+void assembleMforStatement(mforStatementBodyType *mforStatement);
+void assembleMifStatement(mifStatementBodyType *mifStatement, int cumulativeLineNumber);
+void assembleMswitchStatement(mswitchStatementBodyType *mswitchStatement);
+void assembleMvariableStatement(mvariableStatementBodyType *mvariableStatement);
+void assembleMwhileStatement(mwhileStatementBodyType *mwhileStatement);
+void assembleOrgStatement(orgStatementBodyType *orgStatement);
+void assemblePerformStatement(performStatementBodyType *performStatement);
+void assembleRelStatement(relStatementBodyType *relStatement);
+void assembleStartStatement(startStatementBodyType *startStatement);
+void assembleStringStatement(stringStatementBodyType *stringStatement);
+void assembleStructStatement(structStatementBodyType *structStatement);
+void assembleTargetStatement(targetStatementBodyType *targetStatement);
+void assembleUndefineStatement(undefineStatementBodyType *undefineStatement);
+void assembleVariableStatement(variableStatementBodyType *variableStatement);
+void assembleWhileStatement(whileStatementBodyType *whileStatement);
+void assembleWordStatement(wordStatementBodyType *wordStatement);
+bool assembleStatementBody(statementKindType kind, statementBodyType body, int cumulativeLineNumber, bool worryAboutIf, simpleFixupListType **ifFixupList);
+void assembleLabelList(labelListType *labelList);
+simpleFixupListType *assembleStatement(statementType *statement, bool insideIf, simpleFixupListType *ongoingFixupList);
+void eatStatement(statementType *statement);
+
+#endif


### PR DESCRIPTION
Much of the code in the initial macross code uses local function declarations to refer to functions in other files. It does this without full prototypes because the code predates ANSI C.

Unfortunately, gcc interprets that as a prototype that demands functions of no arguments.

I've pushed all those declarations into relatively thorough .h files for the files that needed it and removed the local declarations from those files. This also required altering some calls, because it turns out that omitting arguments or providing extra unused ones was being used as some kind of poor man's varargs or optional arguments. I've also normalized all the calls to keep signatures uniform.

While a few of these functions (mostly related to listing and errors) would benefit from being _made_ varargs, that is not part of this pull request.
