### PR TITLE
mkstemp fix

### DIFF
--- a/initialize.c
+++ b/initialize.c
@@ -337,7 +337,7 @@ initializeStuff(int argc, char **argv)
 	installCommandLineDefineSymbols();
 
 	if (listingOn) {
-		if ((saveFileForPass2 = fopen(mkstemp(pass2SourceFileName),
+		if ((saveFileForPass2 = fdopen(mkstemp(pass2SourceFileName),
 				"w+")) == NULL) {
 			fatalSystemError(UNABLE_TO_OPEN_PASS_2_FILE_ERROR,
 					pass2SourceFileName);
@@ -346,7 +346,7 @@ initializeStuff(int argc, char **argv)
 			unlink(pass2SourceFileName); /* will take effect on
 							program exit */
 
-		if ((indexFileForPass2 = fopen(mkstemp(pass2IndexFileName),
+		if ((indexFileForPass2 = fdopen(mkstemp(pass2IndexFileName),
 				"w+")) == NULL) {
 			fatalSystemError(UNABLE_TO_OPEN_PASS_2_FILE_ERROR,
 					pass2IndexFileName);
@@ -356,7 +356,7 @@ initializeStuff(int argc, char **argv)
 							program exit */
 
 		if (expandMacros) {
-			if ((macroFileForPass2 = fopen(mkstemp(
+			if ((macroFileForPass2 = fdopen(mkstemp(
 				pass2MacroExpansionFileName),"w+")) == NULL) {
 				fatalSystemError(
 					UNABLE_TO_OPEN_PASS_2_FILE_ERROR,


### PR DESCRIPTION
`mkstemp` returns a file descriptor.  Trying to `fopen`() that is a bad idea.
