### PR TITLE
Better checks for null operands

### DIFF
--- a/expressionSemantics.c
+++ b/expressionSemantics.c
@@ -1109,7 +1109,8 @@ evaluateExpressionInternally(expressionType *expression, bool isTopLevel, fixupK
 evaluateExpression(expressionType *expression, fixupKindType kindOfFixup)
 {
 	valueType	*result;
-
+	nullEvaluate(expression);
+	
 	expressionFailed = FALSE;
 	referencesToNote[currentOperandNumber] = NULL;
 	result = evaluateExpressionInternally(expression, TRUE, kindOfFixup,

--- a/operandStuffSD_6502.c
+++ b/operandStuffSD_6502.c
@@ -299,6 +299,7 @@ evaluateOperand(operandType *operand)
 	case Y_INDEXED_OPND:
 		result = evaluateExpression(operand->theOperand.expressionUnion,
 			performingFixups ? NO_FIXUP : OPERAND_FIXUP);
+		nullEvaluate(result);
 		if (operand->kindOfOperand != EXPRESSION_OPND) {
 			if (result->addressMode != EXPRESSION_OPND) {
 				error(BAD_ADDRESS_MODE_ERROR);


### PR DESCRIPTION
The parser accepts `@x` and `@y` as operands. Maybe it's for macros, maybe it's an oversight, maybe it was a future enhancement of some sort. Either way, doing that will crash due to a `NULL` dereference

```
lda @x
lda @y
```

Before:

```
 Segmentation fault: 11
```

After:

```
"<standard input>", line 1: illegal address mode for 'lda' instruction
```
