### PR TITLE
fix macro listings (-m w/ -l).  

### DIFF
--- a/listing.c
+++ b/listing.c
@@ -492,7 +492,7 @@ labeledLine(void)
 vaddText(char *buffer, char **bufferPtr, char *format, va_list ap)
 {
 	vsprintf(*bufferPtr, format, ap);
-	*bufferPtr = buffer = strlen(buffer);
+	*bufferPtr = buffer + strlen(buffer);
 }
 
   void
@@ -521,7 +521,7 @@ moreText(char *format, ...)
 {
 	va_list ap;
 	va_start(ap, format);
-	addText(expansionString, &expansionStringPtr, format, ap);
+	vaddText(expansionString, &expansionStringPtr, format, ap);
 	va_end(ap);
 }
 


### PR DESCRIPTION
The previous var args update has a couple lingering bugs.

before:

```
./macross -l - -m  test/macro.m
Segmentation fault: 11
```

after:

```
./macross -l - -m  test/macro.m
                   macro nop2  {
                           nop
                           nop
                   }

0000                       nop2
0000  ea           +       nop     
0001  ea           +       nop
```
